### PR TITLE
Use alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
-FROM python:3
+FROM python:3-alpine
 
-RUN pip install docker psycopg2
+RUN apk add --no-cache \
+            --virtual psycodeps \
+        gcc \
+        musl-dev \
+        postgresql-dev \
+        python3-dev && \
+    pip install docker psycopg2 && \
+    apk del psycodeps
 
 ADD manager.py /
 
 # the manager creates a file when ready to consume events
-HEALTHCHECK --interval=1s --start-period=1s CMD /bin/bash -c 'test -f /manager-ready'
+HEALTHCHECK --interval=1s --start-period=1s CMD /bin/sh -c 'test -f /manager-ready'
 
 # -u necessary to flush logging to docker in a timely manner
 CMD [ "python", "-u", "./manager.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
         postgresql-dev \
         python3-dev && \
     pip install docker psycopg2 && \
+    apk add --no-cache libpq && \
     apk del psycodeps
 
 ADD manager.py /


### PR DESCRIPTION
Using the plain python image results in our membership manager being nearly a full gigabyte, which is pretty ridiculous. The previous workerlist-gen was around 20MB, so the large size slowed down first-run experience substantially. This should fix things.
