### PR TITLE
Wait for master to come online

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -64,7 +64,7 @@ def connect_to_master():
 # main logic loop for the manager
 def docker_checker():
     client = docker.DockerClient(base_url='unix:///var/run/docker.sock')
-    actions = {'health_status: healthy': add_worker, 'die': remove_worker}
+    actions = {'health_status: healthy': add_worker, 'destroy': remove_worker}
 
     # creates the necessary connection to make the sql calls if the master is ready
     conn = connect_to_master()


### PR DESCRIPTION
In docker compose version 3, the support for `condition` in `depends_on` configuration has been dropped. From [docs](https://docs.docker.com/compose/compose-file/#depends_on)

> depends_on does not wait for db and redis to be “ready” before starting web - only until they have been started. 

Moreover, it expects startup order to be [controlled](https://docs.docker.com/compose/startup-order/) by the application. 

By the change in this PR, membership manager will wait for master to come online, instead of exiting on `psycopg2.OperationalError` exception. This will allow the docker-compose file to be easily ported to version 3

My docker-compose.yml

```
version: "3"

services:
  citus_master:
    container_name: "${COMPOSE_PROJECT_NAME:-citus}_master"
    image: "citusdata/citus:8.3.1"
    labels: ["com.citusdata.role=Master"]
  citus_manager:
    container_name: "${COMPOSE_PROJECT_NAME:-citus}_manager"
    image: "pushowl/citus-membership-manager:0.2.0"
    volumes: ["/var/run/docker.sock:/var/run/docker.sock"]
    environment:
      - CITUS_HOST=citus_master
    depends_on:
      - citus_master
  citus_worker:
    image: "citusdata/citus:8.3.1"
    labels: ["com.citusdata.role=Worker"]
    depends_on:
      - citus_manager
```