### PR TITLE
not use pg_dist_shard_placement which is deprecated

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -29,7 +29,7 @@ def remove_worker(conn, host):
 
     print("removing %s" % host, file=stderr)
     cur.execute("""DELETE FROM pg_dist_placement WHERE groupid = (SELECT groupid FROM 
-                   pg_dist_node WHERE nodename = %(host)s AND nodeport = %(port)s);
+                   pg_dist_node WHERE nodename = %(host)s AND nodeport = %(port)s LIMIT 1);
                    SELECT master_remove_node(%(host)s, %(port)s)""", worker_dict)
 
 

--- a/manager.py
+++ b/manager.py
@@ -28,8 +28,8 @@ def remove_worker(conn, host):
     worker_dict = ({'host': host, 'port': 5432})
 
     print("removing %s" % host, file=stderr)
-    cur.execute("""DELETE FROM pg_dist_shard_placement WHERE nodename=%(host)s AND
-                                                             nodeport=%(port)s;
+    cur.execute("""DELETE FROM pg_dist_placement WHERE groupid = (SELECT groupid FROM 
+                   pg_dist_node WHERE nodename = %(host)s AND nodeport = %(port)s);
                    SELECT master_remove_node(%(host)s, %(port)s)""", worker_dict)
 
 


### PR DESCRIPTION
`pg_dist_shard_placement` is deprecated. This PR updates it to use `pg_dist_node` and `pg_dist_placement`.

