### PR TITLE
Start polling for connections to coordinator node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache \
 ADD manager.py /
 
 # the manager creates a file when ready to consume events
-HEALTHCHECK --interval=1s --start-period=1s CMD /bin/sh -c 'test -f /manager-ready'
+HEALTHCHECK --interval=1s --start-period=1s CMD /bin/sh -c 'test -f /healthcheck/manager-ready'
 
 # -u necessary to flush logging to docker in a timely manner
 CMD [ "python", "-u", "./manager.py"]


### PR DESCRIPTION
Docker Version 3 has some changes in service dependency definitions. We designed Citus `docker-compose.yml` in a way that the services should be run in the order below:
1. Citus Coordinator service
2. Membership-manager
3. Citus Worker services

Docker Compose Version 3 no longer supports [`depends_on`](https://docs.docker.com/compose/compose-file/#depends_on) statements.

[Docker startup order docs](https://docs.docker.com/compose/startup-order/) also state that:
> ... for startup Compose does not wait until a container is “ready” (whatever that means for your particular application) - only until it’s running. There’s a good reason for this.

This means that it is now the responsibility of the manager to be aware that the coordinator is ready to accept connections. To accomplish that we create a polling mechanism to connect to the coordinator.

Similarly, the worker services should be able to understand if the `membership-manager` is ready, and this will be done via the existence of the file `/healthcheck/manager-ready` that will reside in a volume `/healthcheck` that is also attached to the worker nodes.