### PR TITLE
Create /healthcheck dir to avoid startup crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache \
     apk add --no-cache libpq && \
     apk del psycodeps
 
+RUN mkdir -p /healthcheck
 ADD manager.py /
 
 # the manager creates a file when ready to consume events


### PR DESCRIPTION
When membership manager initializes, it touches /healthcheck/manager-read with `open(HEALTHCHECK_FILE, 'a').close()`. That command errors if the host directory doesn't exist.